### PR TITLE
2 small fixes to prevent code from breaking in copying and sequentialMNIST tasks

### DIFF
--- a/event_based/mnist_seq_data_classify.py
+++ b/event_based/mnist_seq_data_classify.py
@@ -25,9 +25,9 @@ Returns:
     y: (784,50000) int32.
 '''
 
-def mnist_data():
-    mnist_trainset = datasets.MNIST(root='/home/anirudh/blocks/sparse_relational/data', train=True, download=True, transform = torchvision.transforms.Compose([torchvision.transforms.ToTensor()]))
-    mnist_testset = datasets.MNIST(root='/home/anirudh/blocks/sparse_relational/data', train=False, download=True, transform=torchvision.transforms.Compose([torchvision.transforms.ToTensor()]))
+def mnist_data(path):
+    mnist_trainset = datasets.MNIST(root=path, train=True, download=True, transform = torchvision.transforms.Compose([torchvision.transforms.ToTensor()]))
+    mnist_testset = datasets.MNIST(root=path, train=False, download=True, transform=torchvision.transforms.Compose([torchvision.transforms.ToTensor()]))
 
     num_val = len(mnist_trainset) // 5
     np.random.seed(0)

--- a/event_based/train_copying.py
+++ b/event_based/train_copying.py
@@ -268,8 +268,8 @@ def evaluate_(copy_x, copy_y):
     with torch.no_grad():
         for i in range(num_batches):
             batch_ind = random.randint(0, num_batches-1)
-            data = Variable(copy_x[batch_ind].cuda())
-            targets = Variable(copy_y[batch_ind].cuda())
+            data = Variable(copy_x[batch_ind].cuda()) if args.cuda else Variable(copy_x[batch_ind])
+            targets = Variable(copy_y[batch_ind].cuda()) if args.cuda else Variable(copy_y[batch_ind])
             #output, hidden,extra_loss = model(data, hidden)
             output, hidden, extra_loss, _, _ = model(data, hidden, calc_mask)
             if not args.adaptivesoftmax:
@@ -302,10 +302,11 @@ def train(epoch):
         batch_ind = random.randint(0, num_batches-1)
 
         #data, targets = get_batch(train_data, i)
-        data = Variable(copy_x[batch_ind].cuda())
-        targets = Variable(copy_y[batch_ind].cuda())
+        data = Variable(copy_x[batch_ind].cuda()) if args.cuda else Variable(copy_x[batch_ind])
+        targets = Variable(copy_y[batch_ind].cuda()) if args.cuda else Variable(copy_y[batch_ind])
 
-        torch.cuda.synchronize()
+        if args.cuda:
+            torch.cuda.synchronize()
         forward_start_time = time.time()
         hidden = repackage_hidden(hidden)
         model.zero_grad()
@@ -318,7 +319,8 @@ def train(epoch):
             _, loss = criterion_adaptive(output.view(-1, args.nhid), targets)
         total_loss += loss.item()
 
-        torch.cuda.synchronize()
+        if args.cuda:
+            torch.cuda.synchronize()
 
         forward_elapsed = time.time() - forward_start_time
         forward_elapsed_time += forward_elapsed

--- a/event_based/train_copying.py
+++ b/event_based/train_copying.py
@@ -273,8 +273,9 @@ def evaluate_(copy_x, copy_y):
             #output, hidden,extra_loss = model(data, hidden)
             output, hidden, extra_loss, _, _ = model(data, hidden, calc_mask)
             if not args.adaptivesoftmax:
-                loss = criterion(output.view(-1, ntokens), targets.view((args.test_len + 20)*64))
+                loss = criterion(output.view(-1, ntokens), targets.reshape((args.test_len + 20) * 64))
             else:
+                raise Exception('not implemented')
                 _, loss = criterion_adaptive(output.view(-1, args.nhid), targets)
             total_loss += loss.item()
             hidden = repackage_hidden(hidden)
@@ -311,7 +312,7 @@ def train(epoch):
 
         output, hidden, extra_loss, masks, sample_masks = model(data, hidden, calc_mask)
         if not args.adaptivesoftmax:
-            loss = criterion(output.view(-1, ntokens), targets.view((args.train_len + 20)*64))
+            loss = criterion(output.view(-1, ntokens), targets.reshape((args.train_len + 20) * 64))
         else:
             raise Exception('not implemented')
             _, loss = criterion_adaptive(output.view(-1, args.nhid), targets)

--- a/event_based/train_mnist.py
+++ b/event_based/train_mnist.py
@@ -138,7 +138,7 @@ device = torch.device("cuda" if args.cuda else "cpu")
 
 # Get Data Loaders
 
-train_loader, val_loader, test_loader = mnist_data()
+train_loader, val_loader, test_loader = mnist_data(path=os.getcwd() + '/mnist_data')
 
 # Starting from sequential data, batchify arranges the dataset into columns.
 # For instance, with the alphabet as the sequence and batch size 4, we'd get


### PR DESCRIPTION
- in `train_copying.py`, a view was applied to a non-contiguous tensor, causing the code to break. Use reshape instead
- in `mnist_seq_data_classify.py`, a hard-coded path was replaced by current working directory
- copying task can now run without gpu (which I needed for debugging)